### PR TITLE
【Fixed】add_generate _suport

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,10 @@ module Achieve
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
     config.action_view.field_error_proc = proc { |html_tag, instance| html_tag }
+
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
   end
 end


### PR DESCRIPTION
#3 

rails generate controller 実行時に無駄な helper や assets を生成しないよう、
config/application.rbファイル内にコードを追加しました。